### PR TITLE
jdk: use amazoncorretto and alpine versions

### DIFF
--- a/service-job/Dockerfile
+++ b/service-job/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM amazoncorretto:17-alpine
 VOLUME /tmp
 EXPOSE 8301
 COPY target/service-job-0.0.1-SNAPSHOT.jar app.jar

--- a/service-recruiter/Dockerfile
+++ b/service-recruiter/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM amazoncorretto:17-alpine
 VOLUME /tmp
 EXPOSE 8302
 COPY target/service-recruiter-0.0.1-SNAPSHOT.jar app.jar

--- a/service-test/Dockerfile
+++ b/service-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM amazoncorretto:17-alpine
 VOLUME /tmp
 EXPOSE 8300
 COPY target/service-test-0.0.1-SNAPSHOT.jar app.jar


### PR DESCRIPTION
reduces image size and vulnerabilities (openjdk isn’t updated for two years)